### PR TITLE
fmDNS - PHP error fix

### DIFF
--- a/server/fm-modules/fmDNS/classes/class_records.php
+++ b/server/fm-modules/fmDNS/classes/class_records.php
@@ -152,6 +152,7 @@ class fm_dns_records {
 		global $fmdb, $__FM_CONFIG, $fm_dns_zones;
 		
 		$_domain_id = 0;
+		$log_message = '';
 		
 		/** Get correct domain name */
 		if ($record_type == 'SOA') {


### PR DESCRIPTION
Fixed this error:

Notice: Undefined variable: log_message in /var/www/fm/fm-modules/fmDNS/classes/class_records.php on line 191